### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ from exoplanet_core import quad_limbdark_light_curve
 u1, u2 = 0.3, 0.2
 ror = 0.05
 b = # Compute the impact parameter as a function of time
-flux = quad_limbdark_light_curve(b, ror)
+flux = quad_limbdark_light_curve(u1, u2, b, ror)
 ```
 
 where `u1` and `u2` are the usual limb darkening parameters and the resulting


### PR DESCRIPTION
Hey Dan,

So I ran a conda update and it updated to exoplanet 0.5 and promptly broke all my code. Looks like `exoplanet.theano_ops` disappeared, and the changelog seems to say you put it over here. 

Looking through this readme, it seems like `exoplanet.theano_ops.driver.SimpleLimbDark` has been turned into `exoplanet_core.quad_limbdark_light_curve`. Is that correct? And I had been using:

```
    ld = SimpleLimbDark()
    ld.set_u([-1, u1, u2])
    return 1 + ld.apply(bs, r2r1)
```

Can I now use 
```
return 1 + quad_limbdark_light_curve(u1, u2, bs, r2r1)
```
as a drop in replacement?

Also, I'm changing your readme because it looks like you never actually feed the function the u1 and u2 parameters in the example, which it appears you need based on the function definition.