### PR TITLE
Add PyMC 6 / PyTensor 3 compatibility for pymc ops

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,5 +38,5 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m nox --non-interactive --error-on-missing-interpreter \
+          python -m nox --non-interactive --error-on-missing-interpreters \
             --session ${{ matrix.session }}-${{ matrix.python-version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+`exoplanet-core` is the compiled C++ backend for the [exoplanet](https://github.com/exoplanet-dev/exoplanet/) project. It provides three astronomical computations — Kepler's equation solver, quadratic limb-darkening solution vector, and orbital contact points — exposed through three Python interfaces: NumPy, JAX, and PyMC (v5+). PyMC3 (Theano-based) is also supported as a legacy interface.
+
+## Build
+
+The package uses `scikit-build-core` with `pybind11` to compile the C++ extension. To install for development:
+
+```bash
+pip install -e ".[test]"
+# For optional backends:
+pip install -e ".[test,jax]"
+pip install -e ".[test,pymc]"
+```
+
+The build produces two shared libraries: `driver` (numpy/pymc backend) and `cpu_driver` (JAX backend). GPU (CUDA) support is opt-in via `EXOPLANET_CORE_CUDA=yes` environment variable at build time.
+
+## Testing
+
+Tests are run per-backend via nox sessions:
+
+```bash
+# Run all default tests (numpy ops)
+python -m nox -s test
+
+# Run a specific backend's tests
+python -m nox -s test_jax
+python -m nox -s test_pymc
+python -m nox -s test_pymc3
+
+# Run a single test file directly (after pip install -e .)
+pytest tests/numpy_test.py
+pytest tests/jax_test.py -v
+
+# Run a single test
+pytest tests/numpy_test.py::test_kepler
+```
+
+## Linting and formatting
+
+```bash
+# Format with black and isort (via pre-commit)
+pre-commit run --all-files
+
+# Or individually:
+black src tests
+isort src tests
+```
+
+Line length is 79. `black` and `isort` config is in `pyproject.toml`.
+
+## Architecture
+
+### Layer structure
+
+```
+C++ headers (src/exoplanet_core/lib/include/exoplanet/)
+    ↓ compiled via pybind11
+driver.so  (numpy/pymc)      cpu_driver.so  (JAX)
+    ↓                              ↓
+numpy/ops.py               jax/ops.py (JAX primitives with JVP/batching rules)
+pymc/ops.py (pytensor Ops)
+    ↓
+core.py  (top-level convenience functions using numpy backend)
+__init__.py  (re-exports kepler + quad_limbdark_light_curve from core.py)
+```
+
+### The three ops
+
+All three interfaces (`exoplanet_core.numpy.ops`, `exoplanet_core.jax.ops`, `exoplanet_core.pymc.ops`) expose the same three functions:
+
+- **`kepler(mean_anomaly, eccentricity)`** → `(sin_f, cos_f)`: Solves Kepler's equation and returns the sine/cosine of the true anomaly. All inputs must be `float64`.
+- **`quad_solution_vector(b, r)`** → `s` of shape `(..., 3)`: Computes the Agol et al. (2020) solution vector for quadratic limb darkening.
+- **`contact_points(a, e, cosw, sinw, cosi, sini, L)`** → `(M_left, M_right, flag)`: Finds orbital contact point mean anomalies; `flag != 0` means no transit.
+
+### C++ core
+
+`src/exoplanet_core/lib/include/exoplanet/` contains the header-only C++ implementations:
+- `kepler.h`: Fast Kepler solver (Brandt et al.)
+- `limbdark.h`: Quadratic limb-darkening solution vector with optional gradient output
+- `contact_points.h`: Transit contact point solver
+- `ellip.h`: Elliptic integral helpers
+
+### JAX integration
+
+`jax/ops.py` registers custom XLA primitives (`kepler_prim`, `quad_solution_vector_prim`, `contact_points_prim`) with JVP rules and batching rules. The `_lowering_rule` dispatches to CPU or CUDA XLA custom calls. The `quad_solution_vector` primitive internally returns `(s, dsdb, dsdr)` — the public `quad_solution_vector` function strips the gradient outputs.
+
+### PyMC integration
+
+`pymc/ops.py` defines pytensor `Op` subclasses (`Kepler`, `QuadSolutionVector`, `ContactPoints`) with `perform`, `grad`, and `R_op` methods. These wrap the same `driver` shared library as the numpy ops. `pymc/jax_support.py` bridges the pytensor ops to JAX when using PyMC with a JAX backend.
+
+### Version
+
+Version is managed by `setuptools_scm` from git tags and written to `src/exoplanet_core/exoplanet_core_version.py` at build time (this file is not in the repo but is included in sdists).

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,38 @@
+PyMC 6 / PyTensor 3 Compatibility Update
+==========================================
+
+Problem
+-------
+PyTensor 3 (shipped with PyMC 6) renamed two Op method pairs that exoplanet-core
+relied on, causing import and runtime failures:
+
+  grad(inputs, output_grads)       -> pullback(inputs, outputs, cotangents)
+  R_op(inputs, eval_points)        -> pushforward(inputs, outputs, tangents)
+
+Files Changed
+-------------
+src/exoplanet_core/pymc/ops.py
+  - Kepler: added pullback() with the correct new signature; kept grad() as a
+    one-liner shim (delegates to pullback) for PyTensor 2 / PyMC 5 compatibility.
+    Added pushforward() implementing the analytic JVP for sinf and cosf.
+    Kept R_op() as a one-liner shim (delegates to pushforward) for PyMC 5 compat.
+    Both pullback() and pushforward() accept the pre-computed forward outputs
+    from PyTensor 3 (avoiding a redundant graph node) and fall back to
+    recomputing via self() when called from the PyTensor 2 shims (outputs=[]).
+  - QuadSolutionVector: same pattern. pullback() carries the VJP logic for the
+    solution vector s; pushforward() computes d_s = dsdb*db + dsdr*dr and marks
+    the derivative outputs (dsdb, dsdr) as DisconnectedType. Both methods use
+    the pre-computed outputs (s, dsdb, dsdr) when available, avoiding a second
+    call to the more expensive quad_solution_vector_with_grad C++ function.
+  - ContactPoints: no gradient methods existed before or after; no changes needed.
+
+pyproject.toml
+  - Added pytensor>=2.0 as an explicit dependency alongside pymc>=5.0.0.
+
+CLAUDE.md
+  - Created initial codebase documentation for future Claude Code sessions.
+
+Test Results
+------------
+PyMC 5.28.5 / PyTensor 2.38.3:  13/13 passed
+PyMC 6.0.1  / PyTensor 3.0.7:   13/13 passed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = ["numpy"]
 
 [project.optional-dependencies]
 pymc3 = ["pymc3>=3.9", "numpy<1.22"]
-pymc = ["pymc>=5.0.0"]
+pymc = ["pymc>=5.0.0", "pytensor>=2.0"]
 jax = ["jax", "jaxlib"]
 test = ["pytest"]
 comparison = ["batman-package", "starry", "numpy<1.22", "xarray<2023.10.0"]

--- a/src/exoplanet_core/pymc/ops.py
+++ b/src/exoplanet_core/pymc/ops.py
@@ -76,9 +76,9 @@ class Kepler(op.Op):
         cosf = resize_or_set(outputs, 1, M.shape)
         driver.solve_kepler(M, ecc, sinf, cosf)
 
-    def grad(self, inputs, gradients):
+    def pullback(self, inputs, outputs, cotangents):
         M, e = inputs
-        sinf, cosf = self(M, e)
+        sinf, cosf = outputs if outputs else self(M, e)
 
         ecosf = e * cosf
         ome2 = 1 - e**2
@@ -88,23 +88,43 @@ class Kepler(op.Op):
         bM = pt.zeros_like(M)
         be = pt.zeros_like(M)
         if not isinstance(
-            gradients[0].type, pytensor.gradient.DisconnectedType
+            cotangents[0].type, pytensor.gradient.DisconnectedType
         ):
-            bM += gradients[0] * cosf * dfdM
-            be += gradients[0] * cosf * dfde
+            bM += cotangents[0] * cosf * dfdM
+            be += cotangents[0] * cosf * dfde
 
         if not isinstance(
-            gradients[1].type, pytensor.gradient.DisconnectedType
+            cotangents[1].type, pytensor.gradient.DisconnectedType
         ):
-            bM -= gradients[1] * sinf * dfdM
-            be -= gradients[1] * sinf * dfde
+            bM -= cotangents[1] * sinf * dfdM
+            be -= cotangents[1] * sinf * dfde
 
         return [bM, be]
 
+    # Backward compatibility with PyTensor < 3 which calls grad() instead of pullback()
+    def grad(self, inputs, gradients):
+        return self.pullback(inputs, [], gradients)
+
+    def pushforward(self, inputs, outputs, tangents):
+        M, e = inputs
+        sinf, cosf = outputs if outputs else self(M, e)
+
+        ecosf = e * cosf
+        ome2 = 1 - e**2
+        dfdM = (1 + ecosf) ** 2 / ome2**1.5
+        dfde = (2 + ecosf) * sinf / ome2
+
+        dM = tangents[0]
+        de = tangents[1]
+
+        d_sinf = cosf * dfdM * dM + cosf * dfde * de
+        d_cosf = -sinf * dfdM * dM - sinf * dfde * de
+
+        return [d_sinf, d_cosf]
+
+    # Backward compatibility with PyTensor < 3 which calls R_op() instead of pushforward()
     def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return eval_points
-        return self.grad(inputs, eval_points)
+        return self.pushforward(inputs, [], eval_points)
 
 
 kepler = Kepler()
@@ -169,12 +189,12 @@ class QuadSolutionVector(op.Op):
         dsdr = resize_or_set(outputs, 2, shape)
         driver.quad_solution_vector_with_grad(b, r, s, dsdb, dsdr)
 
-    def grad(self, inputs, gradients):
+    def pullback(self, inputs, outputs, cotangents):
         b, r = inputs
-        s, dsdb, dsdr = self(b, r)
-        bs = gradients[0]
+        s, dsdb, dsdr = outputs if outputs else self(b, r)
+        bs = cotangents[0]
 
-        for g in gradients[1:]:
+        for g in cotangents[1:]:
             if not isinstance(g.type, pytensor.gradient.DisconnectedType):
                 raise ValueError(
                     "Backpropagation is only supported for the solution vector"
@@ -188,10 +208,29 @@ class QuadSolutionVector(op.Op):
 
         return [pt.sum(bs * dsdb, axis=-1), pt.sum(bs * dsdr, axis=-1)]
 
+    # Backward compatibility with PyTensor < 3 which calls grad() instead of pullback()
+    def grad(self, inputs, gradients):
+        return self.pullback(inputs, [], gradients)
+
+    def pushforward(self, inputs, outputs, tangents):
+        b, r = inputs
+        _, dsdb, dsdr = outputs if outputs else self(b, r)
+        db = tangents[0]
+        dr = tangents[1]
+
+        # Only pushforward for the solution vector s (output 0);
+        # dsdb and dsdr are not differentiable here.
+        d_s = dsdb * db[..., None] + dsdr * dr[..., None]
+
+        return [
+            d_s,
+            pytensor.gradient.DisconnectedType()(),
+            pytensor.gradient.DisconnectedType()(),
+        ]
+
+    # Backward compatibility with PyTensor < 3 which calls R_op() instead of pushforward()
     def R_op(self, inputs, eval_points):
-        if eval_points[0] is None:
-            return eval_points
-        return self.grad(inputs, eval_points)
+        return self.pushforward(inputs, [], eval_points)
 
 
 _quad_solution_vector = QuadSolutionVector()


### PR DESCRIPTION
## Summary

- **PyTensor 3** (shipped with PyMC 6) renamed two `Op` method pairs that
  `exoplanet_core/pymc/ops.py` relied on, causing failures when using PyMC 6:
  - `grad(inputs, output_grads)` → `pullback(inputs, outputs, cotangents)`
  - `R_op(inputs, eval_points)` → `pushforward(inputs, outputs, tangents)`
- Added `pullback()` and `pushforward()` with the correct PyTensor 3 signatures
  to `Kepler` and `QuadSolutionVector`.
- Kept `grad()` and `R_op()` as one-liner shims delegating to the new methods,
  preserving full backward compatibility with PyTensor 2 / PyMC 5.
- Both new methods use the pre-computed forward outputs passed by PyTensor 3
  (avoiding a redundant graph node), and fall back to recomputing when called
  from the PyTensor 2 shims.
- `ContactPoints` has no gradient methods and required no changes.

## Test results

| Stack | Result |
|---|---|
| PyMC 5.28.5 / PyTensor 2.38.3 | 13/13 passed |
| PyMC 6.0.1 / PyTensor 3.0.7 | 13/13 passed |

## JAX sampler compatibility note

This PR fixes the standard NUTS (C++ backend) and nutpie paths for PyMC 6.
The JAX-based samplers (blackjax, numpyro via `sample_jax_nuts`) are a
separate concern: `exoplanet_core/jax/ops.py` uses private JAX APIs
(`jax.lib.xla_client`, `jax.interpreters.xla`, etc.) that were removed in
JAX 0.5+, causing the JAX dispatch registration to silently fail. This is
independent of the pytensor 2→3 change and will be addressed in a follow-up PR.

**In the meantime**, JAX samplers continue to work with JAX 0.4.x. The
compatible ceiling versions on that series are:
- numpyro ≤ 0.19.0 (requires JAX ≥ 0.4.25)
- blackjax ≤ 1.3 (requires JAX ≥ 0.4.16)

Both are fully compatible with PyMC 6 and pytensor 3, so users can upgrade
to PyMC 6 today and retain fast JAX-based sampling without waiting for the
JAX fix.
