### PR TITLE
Make the PyMC quad_solution_vector Op differentiable under JAX

### DIFF
--- a/src/exoplanet_core/pymc/jax_support.py
+++ b/src/exoplanet_core/pymc/jax_support.py
@@ -1,3 +1,5 @@
+import jax
+import jax.numpy as jnp
 from pytensor.link.jax.dispatch import jax_funcify
 
 from exoplanet_core.jax import ops as jax_ops
@@ -12,10 +14,50 @@ def jax_funcify_Kepler(op, **kwargs):
     return kepler
 
 
+# The PyTensor QuadSolutionVector Op has three outputs -- (s, dsdb, dsdr) --
+# so its JAX conversion has to return all three, which the public
+# `jax_ops.quad_solution_vector` (single output) cannot do. Calling
+# `_base_quad_solution_vector` directly has the right shape but inherits its
+# lack of a differentiation rule, so the funcified graph evaluates while
+# `jax.grad` of it raises
+#
+#     ValueError: The FFI call to `exoplanet_core_quad_solution_vector`
+#                 cannot be differentiated.
+#
+# That is precisely what a JAX-based NUTS sampler does to a PyMC model
+# (`pymc.sampling.jax` funcifies the *logp* and differentiates it with JAX),
+# so a limb-darkened model worked with the C and numba backends -- where the
+# Op's own `grad` assembles the gradient from outputs 1 and 2 -- but not with
+# `nuts_sampler="numpyro"` or `"blackjax"`.
+#
+# The wrapper below keeps the three-output signature and attaches the same JVP
+# rule the public single-output function uses. `_base_quad_solution_vector`
+# already returns the derivatives, so this adds no extra FFI call.
+#
+# As with `jax_ops.quad_solution_vector`, this supports first-order
+# differentiation only: `dsdb` and `dsdr` carry zero tangents, since
+# differentiating them would need second derivatives the C++ kernel does not
+# compute. PyTensor's gradient graph consumes those two outputs as values
+# rather than re-differentiating them, and a likelihood only ever reads output
+# 0, so no supported use is restricted.
+@jax.custom_jvp
+def _quad_solution_vector_with_grads(b, r):
+    return jax_ops._base_quad_solution_vector(b, r)
+
+
+@_quad_solution_vector_with_grads.defjvp
+def _quad_solution_vector_with_grads_jvp(primals, tangents):
+    b, r = primals
+    db, dr = tangents
+    s, dsdb, dsdr = jax_ops._base_quad_solution_vector(b, r)
+    ds = db[..., None] * dsdb + dr[..., None] * dsdr
+    return (s, dsdb, dsdr), (ds, jnp.zeros_like(dsdb), jnp.zeros_like(dsdr))
+
+
 @jax_funcify.register(pymc_ops.QuadSolutionVector)
 def jax_funcify_QuadSolutionVector(op, **kwargs):
     def quad_solution_vector(b, r):
-        return jax_ops._base_quad_solution_vector(b, r)
+        return _quad_solution_vector_with_grads(b, r)
 
     return quad_solution_vector
 

--- a/tests/pymc_jax_test.py
+++ b/tests/pymc_jax_test.py
@@ -86,6 +86,46 @@ def test_quad_solution_vector(limbdark_data):
     compare_jax_and_py(fg, limbdark_data)
 
 
+def test_quad_solution_vector_jax_grad(limbdark_data):
+    """The JAX conversion must be differentiable by JAX itself.
+
+    ``test_quad_solution_vector`` only compares *values* between the JAX and
+    Python linkers, which passes even when the conversion carries no
+    differentiation rule. A JAX-based NUTS sampler (``pymc.sampling.jax``)
+    instead funcifies the logp and calls ``jax.grad`` on it, so a missing JVP
+    shows up only here -- it used to raise "The FFI call to
+    `exoplanet_core_quad_solution_vector` cannot be differentiated".
+    """
+    import jax.numpy as jnp
+    from pytensor.link.jax.dispatch import jax_funcify
+
+    from exoplanet_core.jax import ops as jax_ops
+    from exoplanet_core.pymc import ops as pymc_ops
+
+    b_val, r_val = limbdark_data
+    b_val = jnp.asarray(b_val)
+    r_val = jnp.asarray(r_val)
+
+    # The JAX callable the linker would use for this Op.
+    impl = jax_funcify(pymc_ops.QuadSolutionVector())
+
+    def summed_solution(bb, rr):
+        return jnp.sum(impl(bb, rr)[0])
+
+    grad_b, grad_r = jax.grad(summed_solution, argnums=(0, 1))(b_val, r_val)
+    assert np.all(np.isfinite(grad_b))
+    assert np.all(np.isfinite(grad_r))
+
+    # d(sum_k s_k)/db is sum_k dsdb_k, which the C++ kernel returns directly.
+    _, dsdb, dsdr = jax_ops._base_quad_solution_vector(b_val, r_val)
+    np.testing.assert_allclose(
+        np.asarray(grad_b), np.asarray(jnp.sum(dsdb, axis=-1)), rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        np.asarray(grad_r), np.asarray(jnp.sum(dsdr, axis=-1)), rtol=1e-6
+    )
+
+
 def test_contact_points():
     args = [pytensor.tensor.scalar() for _ in range(7)]
     out = ops.contact_points(*args)


### PR DESCRIPTION
## The bug

The JAX conversion of the PyTensor `QuadSolutionVector` Op called `_base_quad_solution_vector` directly:

```python
@jax_funcify.register(pymc_ops.QuadSolutionVector)
def jax_funcify_QuadSolutionVector(op, **kwargs):
    def quad_solution_vector(b, r):
        return jax_ops._base_quad_solution_vector(b, r)
    return quad_solution_vector
```

That has the right *shape* — the Op declares three outputs, `(s, dsdb, dsdr)`, which the public single-output `jax_ops.quad_solution_vector` cannot supply — but it inherits the base function's lack of a differentiation rule. The funcified graph therefore evaluates correctly while `jax.grad` of it raises:

```
ValueError: The FFI call to `exoplanet_core_quad_solution_vector` cannot be
differentiated. You can use `jax.custom_jvp` ... to add support.
```

That is exactly the path a JAX-based NUTS sampler takes — `pymc.sampling.jax` funcifies the **logp** and calls `jax.grad` on it, rather than converting PyTensor's own gradient graph. So limb-darkened models worked with the C and numba backends (where the Op's `grad` assembles the gradient from outputs 1 and 2) but failed at HMC init under `nuts_sampler="numpyro"` or `"blackjax"`.

## The fix

Wrap the three-output base call in a `jax.custom_jvp` carrying the same JVP rule the public single-output function already uses. `_base_quad_solution_vector` returns the derivatives from the FFI call that was made anyway, so this adds no extra work.

As with `jax_ops.quad_solution_vector`, this is first-order only: `dsdb` and `dsdr` propagate zero tangents, since differentiating them would need second derivatives the C++ kernel does not compute. Nothing re-differentiates them — PyTensor's gradient graph consumes them as values, and a likelihood only reads output 0 — so no supported use is restricted.

## Test

`tests/pymc_jax_test.py` compared only *values* between the JAX and Python linkers, which passes even with no differentiation rule — that is why this went unnoticed. Added `test_quad_solution_vector_jax_grad`, which takes `jax.grad` through the conversion and checks it against the `dsdb`/`dsdr` the C++ kernel reports.

Verified it fails on `main` with the exact `ValueError` above and passes with the fix.

## Verification

- `tests/pymc_jax_test.py` — 4 passed
- `tests/pymc_test.py`, `tests/jax_test.py`, `tests/numpy_test.py` — 56 passed
- Downstream: a real transit + RV + SED model (EXOZIPPy, 15.5k TESS points) now samples with `nuts_sampler="numpyro"`; its JAX gradient matches the C backend to 12 significant figures (`-89941.51355554153` vs `-89941.51355554`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x7LE4HS2HFJbSrD5tKFvu