### PR TITLE
Raise ImportError, not AttributeError, on a jax without jax.ffi

### DIFF
--- a/src/exoplanet_core/jax/__init__.py
+++ b/src/exoplanet_core/jax/__init__.py
@@ -2,9 +2,35 @@
 
 import logging
 
+import jax
 from jax import config
 
 logger = logging.getLogger(__name__)
+
+# ops.py registers its FFI targets through jax.ffi, which only became public
+# in jax 0.5.0 (it was jax.extend.ffi before that). pyproject already
+# declares jax>=0.5.0 for the "jax" extra, but nothing enforces it at
+# runtime, so an older jax reaches jax.ffi.register_ffi_target and raises
+#
+#     AttributeError: module 'jax' has no attribute 'ffi'
+#
+# from the middle of ops.py. The EXCEPTION TYPE is what matters here:
+# exoplanet_core/pymc/__init__.py wraps its jax_support import in
+# `try: ... except ImportError: pass`, and an AttributeError sails straight
+# through it -- so `import exoplanet_core.pymc` fails outright on an old
+# jax instead of falling back to the non-JAX path. Raising ImportError
+# makes that existing guard behave as intended and gives a direct user of
+# this module an actionable message.
+#
+# Checked before touching jax's x64 config, so a version that is going to
+# be rejected does not first mutate global jax state.
+if not hasattr(jax, "ffi"):
+    raise ImportError(
+        "exoplanet_core.jax requires jax>=0.5.0, which introduced the "
+        f"public jax.ffi module; the installed jax is {jax.__version__}. "
+        "Upgrade jax, or use the numpy or pymc backends, neither of which "
+        "needs it."
+    )
 
 if not config.read("jax_enable_x64"):
     logger.warning(


### PR DESCRIPTION
`ops.py` registers its FFI targets through `jax.ffi`, which became public in jax 0.5.0 (before that it was `jax.extend.ffi`). `pyproject` declares `jax>=0.5.0` for the `jax` extra, but nothing enforces it at runtime, so an older jax gets as far as `jax.ffi.register_ffi_target` and raises

```
AttributeError: module 'jax' has no attribute 'ffi'
```

from the middle of `exoplanet_core/jax/ops.py`.

### The exception type is the actual problem

`exoplanet_core/pymc/__init__.py` wraps its optional jax_support import in

```python
try:
    from exoplanet_core.pymc import jax_support  # noqa
except ImportError:
    pass
```

and an `AttributeError` sails straight through that guard. The result is that **an old jax is worse than no jax at all**:

| installed jax | what happens |
| --- | --- |
| absent | guard catches a real `ImportError`; the PyMC backend loads fine |
| 0.4.x | `AttributeError` escapes; `import exoplanet_core.pymc` fails outright |

...and so does any downstream package that imports it.

This is not hypothetical. It is what makes exoplanet-core unimportable on macOS x86_64, where jaxlib's last wheel is 0.4.38 and jaxlib ships no sdist, so no newer jax can be installed at all. Downstream, it turned `import exozippy` into a hard failure in `components/orbit/orbit.py` with no obvious connection to jax.

### The fix

Checking `hasattr(jax, "ffi")` up front converts that into an `ImportError` naming the requirement and the installed version. That makes the existing pymc guard behave as intended -- **no change needed there** -- and gives a direct user of `exoplanet_core.jax` something actionable.

Deliberately not widening the guard to `except (ImportError, AttributeError)`: that swallows a broad exception class and would hide real bugs inside `jax_support`. Fixing the source keeps the guard precise.

The check runs before the x64 config block, so a jax that is about to be rejected does not first mutate global jax state.

### Verification

Against an installed exoplanet-core with this file patched in:

- with jax 0.11, the module imports and `ops.kepler` / `ops.quad_solution_vector` are present as before;
- with a stand-in jax that has `config` and `extend.ffi` but no `ffi`, the import raises `ImportError` rather than `AttributeError`.

The real-world confirmation of the negative path is a CI run on genuine jax 0.4.38 that produced exactly the `AttributeError` above.

---

### Note on the `test_pymc` CI failure (pre-existing, unrelated)

`test_pymc` fails on this branch with `AttributeError: module 'numpy' has no attribute 'row_stack'`. **It is not caused by this PR**, and it is worth fixing separately.

Proof: a whitespace-only branch off unmodified `main` fails the same job identically ([run 31769171675](https://github.com/jdeast/exoplanet-core/actions/runs/31769171675)) — `test_pymc` red, `test`/`test_jax`/`test_pymc_jax` green, exactly as here. This diff is 26 added lines in `src/exoplanet_core/jax/__init__.py`, and `row_stack` appears nowhere in this repository.

**Cause: `uv run` resolves a numba pre-release.** Versions actually installed in that job ([run 31769900056](https://github.com/jdeast/exoplanet-core/actions/runs/31769900056)):

```
numpy        2.5.2
numba        0.63.0b1     <-- pre-release
llvmlite     0.46.0
pytensor     3.2.4
pymc         6.3.0
```

`numba/np/arrayobj.py` calls `overload(np.row_stack)` at import time, and numpy removed `np.row_stack` in **2.5.0**. Every *final* numba caps numpy against this (`0.63.0` has `numpy<2.4`, `0.66.0` has `numpy<2.5`) — but **`0.63.0b1` declares only `numpy>=1.22`, with no upper bound**, because the cap was added after that beta was published.

So the resolver, wanting the newest numpy and bounded by pytensor's `numba<=0.66.0`, cannot use numba 0.66.0 (it demands `numpy<2.5`) and instead selects the uncapped pre-release. `pip` resolves the same requirements to numba 0.66.0 + numpy 2.4.6, which works — it excludes pre-releases by default; uv's default (`if-necessary-or-explicit`) allows them when needed to find a solution.

`test_pymc_jax` passes with the same extras because it uses the JAX linker and never imports numba.

Two fixes, either sufficient, neither belonging in this PR:

* `[tool.uv] prerelease = "disallow"` in `pyproject.toml`, or
* commit a `uv.lock` so CI stops resolving fresh on every run.

Note that a `numba<=0.66.0` pin would **not** help: `0.63.0b1` already satisfies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
